### PR TITLE
Respect location pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ module.exports = function(opts) {
     if (parsed.query) state.remote = parsed.query.remote
   }
   
-  if (!state.remote) state.remote = window.location.origin
+  // Use the current location and remove a (possible) trailing slash.
+  if (!state.remote) state.remote = window.location.origin + window.location.pathname.replace(/\/$/, '');
   
   var actions = {
     bulkEdit: function() { showDialog('bulkEdit', {name: 'COLUMN'}) },


### PR DESCRIPTION
Let's say we have a dat instance behind a reverse proxy which redirects requests at `http://host-tld/my-dat` to the respective dat. The `dat-editor` tries to communicate with the API at `/api`. This PR respects the given pathname so that the editor will talk with `http://host-tld/my-dat/api`.
